### PR TITLE
Remove `setup-graalvm` warning in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
           distribution: "graalvm-community"
           version: "latest"
           java-version: "21"
-          components: "native-image"
           cache: "sbt"
       - run: sbt scalafmtCheckAll scalafmtSbtCheck
   build:
@@ -29,7 +28,6 @@ jobs:
           distribution: "graalvm-community"
           version: "latest"
           java-version: "21"
-          components: "native-image"
           cache: "sbt"
       - name: Install Sbt (New MacOs ARM64 Runner doesn't have it)
         if: ${{ matrix.os == 'macos-latest-xlarge' }}


### PR DESCRIPTION
The current CI pipeline shows the following warning:
```
Checks
Please remove "components: 'native-image'" from your workflow file. It is automatically included since GraalVM for JDK 17: https://github.com/oracle/graal/pull/5995
```

This fix remove the `components` argument.